### PR TITLE
Update the Chinese translation of "seconds."

### DIFF
--- a/zh_cn.json
+++ b/zh_cn.json
@@ -88,7 +88,7 @@
   "settings_autorun": "自动运行",
   "settings_autorun_desc": "每隔一段时间，此插件尝试自动同步。会影响到电池用量。",
   "settings_autorun_notset": "（不设置）",
-  "settings_autorun_second": "每 {{time}} 秒钟",
+  "settings_autorun_second": "每 {{time}} 秒",
   "settings_autorun_1min": "每 1 分钟",
   "settings_autorun_5min": "每 5 分钟",
   "settings_autorun_10min": "每 10 分钟",

--- a/zh_tw.json
+++ b/zh_tw.json
@@ -88,7 +88,7 @@
   "settings_autorun": "自動執行",
   "settings_autorun_desc": "每隔一段時間，此外掛嘗試自動同步。會影響到電池用量。",
   "settings_autorun_notset": "（不設定）",
-  "settings_autorun_second": "每 {{time}} 秒鐘",
+  "settings_autorun_second": "每 {{time}} 秒",
   "settings_autorun_1min": "每 1 分鐘",
   "settings_autorun_5min": "每 5 分鐘",
   "settings_autorun_10min": "每 10 分鐘",


### PR DESCRIPTION

Lyiton found that in Chinese translations, both "秒" and "秒钟" are used to express "seconds," but the occurrence of these two expressions is not uniform, which is awkward (he's right, it does look awkward). I think "秒" is more concise, so it would be better to uniformly change "秒钟" to "秒."

[Update zh_cn.json by FEI352 · Pull Request #2 · FEI352/langs (github.com)](https://github.com/FEI352/langs/pull/2) 